### PR TITLE
Setting the central coordinates when the map is ready

### DIFF
--- a/WikiNearMe/App.tsx
+++ b/WikiNearMe/App.tsx
@@ -82,6 +82,8 @@ export default function App() {
           longitudeDelta: 0.0421
         }}
         onMapReady={() => {
+          let coor = getCentralCoordinates(region)
+          centralCoordinates = coor
           findArticles()
         }}
         onRegionChange={(region) => {


### PR DESCRIPTION
The central coordinates were not being set when the map was initially loaded causing nothing to be returned with the API request (no markers are loaded)